### PR TITLE
Fix database path issue for use in windows

### DIFF
--- a/R/ConfigurationHelpers.R
+++ b/R/ConfigurationHelpers.R
@@ -28,7 +28,7 @@ readAndParseYaml <- function(pathToYalmFile, ...) {
 
   # replace the values in the yaml file
   for (name in names) {
-    yalmFile <- gsub(paste0("<", name, ">"), list(...)[[name]], yalmFile)
+    yalmFile <- gsub(paste0("<", name, ">"), list(...)[[name]], yalmFile, fixed = TRUE)
   }
 
   # parse the yaml file


### PR DESCRIPTION
Parsing of yaml configuration files was missing path indicator backslashes in database addresses in windows. This is now fixed so that now database tables are created as expected.